### PR TITLE
Oneline Fix for Pyright.

### DIFF
--- a/tests/core_tests/config_test.py
+++ b/tests/core_tests/config_test.py
@@ -55,7 +55,7 @@ class ConfigTestCases(unittest.TestCase):
         test_config_1 = Config(self.param_pos, self.ic_pos)
         test_config_2 = Config(self.param_all, self.ic_all)
         with self.assertRaises(MutationException):
-            test_config_1.init_cond = State(
+            test_config_1.init_cond = StateTime(
                 {"throw": "error"}
             )  # mutating init_cond would throw error
         with self.assertRaises(MutationException):


### PR DESCRIPTION
### Summary
There is a typo in the config-test file. Now, all pyright failures for Config shall be fixed.