### PR TITLE
add *.prof to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 src/.DS_Store
 .pytest_cache
 *.egg-info
+*.prof


### PR DESCRIPTION
### Summary
<!-- What changes were made? What features were added? What bugs were fixed? -->
This PR adds *.prof to the gitignore, so we don't have to manually remove profiling result files.

### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->