### PR TITLE
Implement ArgParse CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,16 @@ pip install -e .
 
 Run
 
-```
-python -V
-```
+Input structure: 
+    ```
+    "python3 src/main.py {file path} [-v]"
+    ```
+    File path is a required argument, verbose is an optional argument.
+Example: 
+    ```
+    "python3 src/main.py configs/freefall.json"
+    "python3 src/main.py configs/test_angles.json -v"
+    ```
 
 in terminal to find your Python version. If it's lower than 3.8, you should upgrade your Python version.
 

--- a/configs/freefall.json
+++ b/configs/freefall.json
@@ -1,0 +1,11 @@
+{
+    "initial_condition": {
+
+        "x": 10000000.0,
+        "y": 1000.0,
+        "z": 1000.0,
+        "ang_vel_x": 4.5,
+        "time": 0.0
+    },
+    "models" : ["pos", "gyro"]
+ }

--- a/configs/test_zeroes.json
+++ b/configs/test_zeroes.json
@@ -9,6 +9,7 @@
         "thruster_force": 0.0
     },
     "initial_condition": {
+        "time" : 0.0,
         
         "ang_vel_x" : 0.0, 
         "ang_vel_y" : 0.0, 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -2,7 +2,8 @@
 
 from typing import Dict, List
 import json
-from jsonschema import validate, Draft3Validator, ValidationError
+from utils.log import log
+from jsonschema import Draft3Validator, ValidationError
 from utils.constants import DEFAULT_MODELS, ModelEnum
 
 from core.parameters import Parameters
@@ -93,8 +94,15 @@ class Config:
                 pass  # there is no "gyro_noise" in the json
 
             json_params = data.get("parameters", {})
+            if json_params == {}:
+                log.warning("parameters are not specified")
             json_init_cond = data.get("initial_condition", {})
+            if json_init_cond == {}:
+                log.warning("initial conditions are not specified")
             json_models = data.get("models", [])
+            if json_models == []:
+                log.warning("models are not specified")
+
             actual_models = []
             for model_str in json_models:
                 actual_models.append(ModelEnum(model_str))

--- a/src/main.py
+++ b/src/main.py
@@ -20,8 +20,10 @@ class SimRunner:
         """
         Runs the sim from specified config path. Called from command-line.
 
-        Input structure: "python3 src/main.py {file path}"
-        Example: "python3 src/main.py configs/freefall.json"
+        Input structure: "python3 src/main.py {file path} {-v}"
+        Example: 
+            "python3 src/main.py configs/freefall.json"
+            "python3 src/main.py configs/test_angles.json -v"
         """
         # if called from somewhere within the program, with config objects
         if config:

--- a/src/main.py
+++ b/src/main.py
@@ -21,8 +21,8 @@ class SimRunner:
         """
         Runs the sim from specified config path. Called from command-line.
 
-        Input structure: "python3 src/main.py --config {file path}"
-        Example: "python3 src/main.py --config configs/test_angles.json"
+        Input structure: "python3 src/main.py {file path}"
+        Example: "python3 src/main.py configs/freefall.json"
         """
         # if called from somewhere within the program, with config objects
         if config:
@@ -35,7 +35,7 @@ class SimRunner:
             parser.add_argument(
                 "config",
                 type=str,
-                help="initialize simulation with given path to json config file.",
+                help="Initialize simulation with given path to json config file.",
             )
 
             # Parser command line arguments

--- a/src/main.py
+++ b/src/main.py
@@ -19,9 +19,11 @@ class SimRunner:
 
     def __init__(self, config: Union[Config, None] = None) -> None:
         """
-        Runs the sim from specified config path. Called from command-line.
+        Runs the sim from specified config path or from a Config Object. 
 
-        Input structure: "python3 src/main.py {file path} {-v}"
+        Input structure: 
+            "python3 src/main.py {file path} [-v]"
+            File path is a required argument, verbose is an optional argument.
         Example: 
             "python3 src/main.py configs/freefall.json"
             "python3 src/main.py configs/test_angles.json -v"

--- a/src/main.py
+++ b/src/main.py
@@ -9,44 +9,40 @@ import pandas as pd
 
 import argparse
 
-_DESCRIPTION = '''CISLUNAR Simulation Runner!'''
+_DESCRIPTION = """CISLUNAR Simulation Runner!"""
+
 
 class SimRunner:
     """
     This class serves as the main entry point to the sim.
     """
 
-
-    def __init__(self, args: Union[str, Config] = "configs/test_zeroes.json") -> None: 
+    def __init__(self, config: Config = None) -> None:
         """
         Runs the sim from specified config path. Called from command-line.
 
         Input structure: "python3 src/main.py --config {file path}"
         Example: "python3 src/main.py --config configs/test_angles.json"
         """
+        # if called from somewhere within the program, with config objects
+        if config:
+            self._sim = CislunarSim(config)
+
         # if called from command line
-        if isinstance(args, str):
+        else:
             # Build the argument parser
-            parser = argparse.ArgumentParser(description= _DESCRIPTION)
+            parser = argparse.ArgumentParser(description=_DESCRIPTION)
             parser.add_argument(
-                '-c', '--config', type = str, help =
-                'json configuration file used to initialize the simulation'
+                "config",
+                type=str,
+                help="initialize simulation with given path to json config file.",
             )
 
             # Parser command line arguments
             args = parser.parse_args()
-            config_path = args.config
-            config = Config.make_config(config_path)
-        # if called from somewhere within the program, with config objects   
-        else:
-            assert isinstance(args, Config)
-            config = args
-        self._sim = CislunarSim(config)
+            self._sim = CislunarSim(Config.make_config(args.config))
+
         self.state_history = []
-
-        self._sim = CislunarSim(cast(Config, config))
-        self.state_history: List[PropagatedOutput] = []
-
 
     def run(self) -> pd.DataFrame:
         """Runs the sim and returns the truth and observed states in a pandas dataframe.
@@ -72,17 +68,6 @@ class SimRunner:
         return self.state_history
 
 
-def freefall():
-    # freefall from ~4000km altitude to test basic functionality of the sim
-    initial_condition = {"x": 10_000_000, "y": 1_000, "z": 1_000, "ang_vel_x": 4.5, "time": 0.0}
-    models_to_use = [ModelEnum.PositionModel, ModelEnum.GyroModel]
-    conf = Config({}, initial_condition, models=models_to_use)
-
-    test_sim = SimRunner(conf)
-    data = test_sim.run()
-    df_to_csv(data)
-
-
 if __name__ == "__main__":
-    # freefall()
-    Simrunner()
+    data = SimRunner().run()
+    df_to_csv(data)

--- a/src/main.py
+++ b/src/main.py
@@ -7,24 +7,46 @@ from core.sim import CislunarSim
 from core.state import PropagatedOutput
 import pandas as pd
 
+import argparse
+
+_DESCRIPTION = '''CISLUNAR Simulation Runner!'''
+
 class SimRunner:
     """
     This class serves as the main entry point to the sim.
     """
 
 
-    def __init__(self, config_path: Union[str, Config] = "data/zeroes.json") -> None: 
-        #TODO: use a file with actual default values, not zeroes
-        if isinstance(config_path, str):
+    def __init__(self, args: Union[str, Config] = "configs/test_zeroes.json") -> None: 
+        """
+        Runs the sim from specified config path. Called from command-line.
+
+        Input structure: "python3 src/main.py --config {file path}"
+        Example: "python3 src/main.py --config configs/test_angles.json"
+        """
+        # if called from command line
+        if isinstance(args, str):
+            # Build the argument parser
+            parser = argparse.ArgumentParser(description= _DESCRIPTION)
+            parser.add_argument(
+                '-c', '--config', type = str, help =
+                'json configuration file used to initialize the simulation'
+            )
+
+            # Parser command line arguments
+            args = parser.parse_args()
+            config_path = args.config
             config = Config.make_config(config_path)
+        # if called from somewhere within the program, with config objects   
         else:
-            assert isinstance(config_path, Config)
-            config = config_path
+            assert isinstance(args, Config)
+            config = args
         self._sim = CislunarSim(config)
         self.state_history = []
 
         self._sim = CislunarSim(cast(Config, config))
         self.state_history: List[PropagatedOutput] = []
+
 
     def run(self) -> pd.DataFrame:
         """Runs the sim and returns the truth and observed states in a pandas dataframe.
@@ -62,4 +84,5 @@ def freefall():
 
 
 if __name__ == "__main__":
-    freefall()
+    # freefall()
+    Simrunner()

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from utils.log import log
 from utils.data_handling import states_to_df, df_to_csv
 import logging
+from typing import Union
 from core.config import Config
 from core.sim import CislunarSim
 import pandas as pd
@@ -16,7 +17,7 @@ class SimRunner:
     This class serves as the main entry point to the sim.
     """
 
-    def __init__(self, config: Config = None) -> None:
+    def __init__(self, config: Union[Config, None] = None) -> None:
         """
         Runs the sim from specified config path. Called from command-line.
 
@@ -26,7 +27,7 @@ class SimRunner:
             "python3 src/main.py configs/test_angles.json -v"
         """
         # if called from somewhere within the program, with config objects
-        if config:
+        if isinstance (config, Config):
             self._sim = CislunarSim(config)
 
         # if called from command line

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,12 @@
-from utils.constants import ModelEnum
 from utils.log import log
 from utils.data_handling import states_to_df, df_to_csv
-from typing import List, Union, cast
+import logging
 from core.config import Config
 from core.sim import CislunarSim
-from core.state import PropagatedOutput
 import pandas as pd
 
 import argparse
+
 
 _DESCRIPTION = """CISLUNAR Simulation Runner!"""
 
@@ -37,9 +36,19 @@ class SimRunner:
                 type=str,
                 help="Initialize simulation with given path to json config file.",
             )
+            parser.add_argument(
+                "-v",
+                "--verbose",
+                action="store_true",
+                help="set the logging level to DEBUG instead of INFO",
+            )
 
             # Parser command line arguments
             args = parser.parse_args()
+
+            # Set Logging level of "Sim" based on --verbose argument.
+            log.setLevel(logging.DEBUG) if args.verbose else log.setLevel(logging.INFO)
+
             self._sim = CislunarSim(Config.make_config(args.config))
 
         self.state_history = []

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -1,14 +1,15 @@
 import cProfile
 import pstats
 
-from main import freefall
+from main import CislunarSim
+from core.config import Config
 
 
 def main():
     # The following line requires Python 3.8+
     # https://github.com/mCodingLLC/VideosSampleCode/issues/5
     with cProfile.Profile() as pr:
-        freefall()
+        CislunarSim(Config.make_config("configs/freefall.json"))
 
     stats = pstats.Stats(pr)
     stats.sort_stats(pstats.SortKey.TIME)


### PR DESCRIPTION
### Summary
Added argparse structure. The __init__ method can use string file path or Config object to initialize a simulation. 
This PR corresponds to [this task card](https://cornell.app.box.com/file/948866787852) and [CISLUNAR-289](https://jira.cornell.edu/browse/CISLUNAR-289).

Two features in argparse:
1. specify config json file directory
2. specify logging level: info or debug

### Testing
Print test and running from command line. There is no test case for this implementation.

### Notes
**To use args to initialize: **
"python3 src/main.py configs/freefall.json -v" logging DEBUG
"python3 src/main.py configs/freefall.json" logging INFO

**To use Config Object to initialize:**
call "SimRunner(conf)" within the program.

*I removed freefall test method and made that a json config file.

### Comments
- [X] Add an x between the brackets if you commented your code well!
