### PR TITLE
convert profiling into util. reorg main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -71,6 +71,7 @@ class SimRunner:
         states = self._run()
         run_df = states_to_df(states)
 
+        log.setLevel(logging.INFO)  # to prevent being spammed by matplotlib's debug logs (doesn't work)
         data_plot = Plot(run_df)
         data_plot.plot_data()
 
@@ -89,6 +90,10 @@ class SimRunner:
         return self.state_history
 
 
-if __name__ == "__main__":
+def run_sim():
     data = SimRunner().run()
     df_to_csv(data)
+
+
+if __name__ == "__main__":
+    run_sim()

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -1,19 +1,28 @@
+"""profiling.py - a util for finding what's slowing down your CislunarSim runs
+
+    Run this sim the same way you would run main.py: `python tests/profiling.py configs/... -v`
+    A sim with the config file and other args you specify will be run, its data stored, and the
+    runtime profile of the sim will be stored to `for_snakeviz.prof`, where you can inspect the
+    results with `snakeviz for_snakeviz.prof`. Install it via `pip install snakeviz`
+    """
+
 import cProfile
 import pstats
 
-from main import CislunarSim
-from core.config import Config
+from main import run_sim
 
 
 def main():
     # The following line requires Python 3.8+
     # https://github.com/mCodingLLC/VideosSampleCode/issues/5
     with cProfile.Profile() as pr:
-        CislunarSim(Config.make_config("configs/freefall.json"))
+        run_sim()
 
     stats = pstats.Stats(pr)
     stats.sort_stats(pstats.SortKey.TIME)
     stats.dump_stats(filename="for_snakeviz.prof")
+
+    # Now you can investigate the results with `snakevix for_snakeviz.prof`
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
<!-- What changes were made? What features were added? What bugs were fixed? -->
This PR make profiling.py into a nifty utility that profiles a run of main.py, and has the same command line interface options as main.py

### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
Ran `python tests/profiling.py configs/freefall.json -v` and then opened with `snakeviz for_snakeviz.prof`, worked great.

### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->
The architecture of putting everything in a file into a "main" function that you can import easily into other files is very underrated and underused. Let's use it more! For reference: [check this out!](https://www.youtube.com/watch?v=g_wlZ9IhbTs)

### Comments
- [x] Add an x between the brackets if you commented your code well!
