### PR TITLE
Strengthen validation and customize max_iter.

### DIFF
--- a/configs/freefall.json
+++ b/configs/freefall.json
@@ -1,4 +1,6 @@
 {
+    "description": "This config models the satellite in free fall motion. The sim runs until the satellite hits the earth. The visualization should display a relatively straight path towards the earth. ",
+	
     "initial_condition": {
 
         "x": 10000000.0,

--- a/configs/schema.json
+++ b/configs/schema.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
 	"type": "object",
+	"description": "This is the schema that is used to validate json files, none of the fields are required, if they are not specified, a default value will be substituted. Type check and spell check are handled by the validation process, so no typo will be allowed. *Be careful to not miss declaring any properties of customization, the program will still run without warning but might not behave as expected!* ",
 	"properties": {
 		"parameters": {
 			"type": "object",
@@ -31,8 +32,12 @@
 				},
 				"thruster_force": {
 					"type": "number"
+				},
+				"max_iter": {
+					"type": "number"
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"initial_condition": {
 			"type": "object",
@@ -94,7 +99,8 @@
 				"solenoid_actuation_on": {
 					"type": "boolean"
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"models": {
 			"type": "array",
@@ -102,5 +108,6 @@
 				"type": "string"
 			}
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/configs/test_fail.json
+++ b/configs/test_fail.json
@@ -1,12 +1,13 @@
-{
+{   
+    "description": "This test case models a json file that has vel_x mistyped. A JsonError should be raised. ",
     "parameters": {
         "thruster_force": 30.0
     },
     "initial_condition": {
 
-        "vel_x" : 38.0, 
+        "velx" : 38.0, 
         "vel_y" : 37.0, 
-        "vel_z" : false, 
+        "vel_z" : 30.0, 
         "propulsion_on": false,
         "solenoid_actuation_on": false
     }

--- a/configs/test_fail2.json
+++ b/configs/test_fail2.json
@@ -1,4 +1,5 @@
 {
+    "description": "This test case violates the requirement that the gyro_bias should have three element in the array. ",
     "parameters": {
         "gyro_bias" : [0.0, 0.0],
         "gyro_noise" : [0.0, 0.0, 0.0]

--- a/configs/test_zeroes.json
+++ b/configs/test_zeroes.json
@@ -9,7 +9,6 @@
         "thruster_force": 0.0
     },
     "initial_condition": {
-        "time" : 0.0,
         
         "ang_vel_x" : 0.0, 
         "ang_vel_y" : 0.0, 

--- a/src/core/parameters.py
+++ b/src/core/parameters.py
@@ -16,6 +16,7 @@ class Parameters:
         self.com = 0
         self.tank_volume = 0
         self.thruster_force = 0
+        self.max_iter = 1e6
 
         for key, value in param_dict.items():
             if key in self.__dict__.keys():

--- a/src/core/sim.py
+++ b/src/core/sim.py
@@ -72,7 +72,7 @@ class CislunarSim:
             log.debug(f"{self.state}")
             return True
 
-        if self.num_iters > 1e6:
+        if self.num_iters > self._config.param.max_iter:
             log.error("Stopping sim because it's running too long")
             return True
 

--- a/src/utils/test_utils.py
+++ b/src/utils/test_utils.py
@@ -59,4 +59,5 @@ d3456 = {
     "com": 4,
     "tank_volume": 5,
     "thruster_force": 6,
+    "max_iter": 1000000
 }

--- a/tests/core_tests/parameters_test.py
+++ b/tests/core_tests/parameters_test.py
@@ -18,6 +18,7 @@ class ParametersTestCase(unittest.TestCase):
             "gyro_sensitivity": 0.015625 * (math.pi / 180),
             "dry_mass": 0,
             "com": 0,
+            "max_iter": 1000000,
             "tank_volume": 0,
             "thruster_force": 0,
         }
@@ -65,6 +66,7 @@ class ParametersTestCase(unittest.TestCase):
                 "com": 0,
                 "tank_volume": 0,
                 "thruster_force": 0,
+                "max_iter": 1000000
             },
             Parameters({}).__dict__,
         )


### PR DESCRIPTION

### Summary
This PR is related to [CISLUNAR-399](https://jira.cornell.edu/browse/CISLUNAR-399). Change timeout max_iter into a parameter in parameters.py. Now we can specify max_iter in config json files. Edited json schema accordingly. Added description in json schema and in example config files. Use "additional properties" to make json validation stricter, now it does not allow typo or unused properties.

### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
Edited test_fail to try different ways of failing, all successfully raised JsonError. Added descrptions to test cases. 

### Notes
Please modify other canonical JSON files accordingly, add description and consider customizing max_iter.


### Comments
- [X] Add an x between the brackets if you commented your code well!
