### PR TITLE
Change dt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ python src/main.py configs/iss.json
 python src/main.py configs/test_angles.json -v
 ```
 
+We recommend setting your `D_T` value (the timestep length) in `constants.py` to be between 100 - 300. If you're looking for a faster run, you'll want to set it on the higher side of that range.
+
 ## Plotting Sim Runs
 
 #### Usage:  

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ python src/main.py configs/iss.json
 python src/main.py configs/test_angles.json -v
 ```
 
-We recommend setting your `D_T` value (the timestep length) in `constants.py` to be between 100 - 300. If you're looking for a faster run, you'll want to set it on the higher side of that range.
+We recommend setting your `D_T` value (the timestep length) in `constants.py` to be between 100 - 300. If you're looking for a faster run, you'll want to set it to be on the higher side of that range.
 
 ## Plotting Sim Runs
 

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -51,4 +51,4 @@ R_EARTH = 6_378_137  # Average Radius of the Earth, meters
 R_MOON = 1_737_100  # Average Radius of the Moon, meters
 R_SUN = 696_340_000
 
-D_T = 0.1  # timestep in seconds
+D_T = 200  # timestep in seconds


### PR DESCRIPTION
### Summary
Default timestep in constants.py is 0.1. It makes more sense to choose a number around 200, or else the data collection is just too slow. 

Also, added a note about it into the README.


### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->


### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->


### Comments
- [ x] Add an x between the brackets if you commented your code well!
