### PR TITLE
Add parens on lru_cache

### DIFF
--- a/src/utils/astropy_util.py
+++ b/src/utils/astropy_util.py
@@ -10,7 +10,7 @@ from astropy.coordinates import SkyCoord
 
 
 # Heavily reference the get_ephemeris function here: https://github.com/Cislunar-Explorers/FlightSoftware/blob/master/OpticalNavigation/core/observe_functions.py
-@lru_cache
+@lru_cache()
 def get_body_position(time: int, body: BodyEnum) -> Tuple[float, float, float]:
     """Gets position vector of [body] based on [time]
 


### PR DESCRIPTION
### Summary
Very small fix on the usage of @lru_cache, where not putting parentheses gives a `TypeError: Expected maxsize to be an integer or None`. This leads to errors when trying to run tests locally.

Below is a copy of the error logs:

```tests/core_tests/model_tests/position_dynamics_model_test.py:2: in <module>
    from core.models.model_list import PositionDynamics
src/core/models/model_list.py:3: in <module>
    from core.models.model import ActuatorModel, EnvironmentModel, SensorModel, MODEL_TYPES
src/core/models/model.py:3: in <module>
    from core.state.statetime import StateTime
src/core/state/statetime.py:4: in <module>
    from core.models.derived_models import DERIVED_MODEL_LIST
src/core/models/derived_models.py:3: in <module>
    from utils.astropy_util import get_body_position
src/utils/astropy_util.py:14: in <module>
    def get_body_position(time: int, body: BodyEnum) -> Tuple[float, float, float]:
/opt/anaconda3/lib/python3.7/functools.py:490: in lru_cache
    raise TypeError('Expected maxsize to be an integer or None')
E   TypeError: Expected maxsize to be an integer or None
```