### PR TITLE
Command line update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ You can exit this environment by running `deactivate`. To re-enter an existing e
 #### Usage:
 
 ```zsh
-python src/main.py {file path} [-v]
+python src/main.py {file path} [-v] [-l]
 ```
 
 #### Options:  
 `file path` *(Required)*: The path of the config file to simulate  
-`-v` *(Optional)*: Verbose mode for logging extra information to the terminal
+`-v` *(Optional)*: Verbose mode for logging extra information to the terminal  
+`-l` *(Optional)*: Headless mode that will not generate a CSV nor plot any data
 
 #### Examples:  
 ```zsh

--- a/README.md
+++ b/README.md
@@ -22,18 +22,21 @@ You can exit this environment by running `deactivate`. To re-enter an existing e
 #### Usage:
 
 ```zsh
-python src/main.py {file path} [-v] [-l]
+python src/main.py config [-v] [-p] [-o [OUT]] 
 ```
 
 #### Options:  
-`file path` *(Required)*: The path of the config file to simulate  
+`config` *(Required)*: The path of the config file to simulate  
 `-v` *(Optional)*: Verbose mode for logging extra information to the terminal  
-`-l` *(Optional)*: Headless mode that will not generate a CSV nor plot any data
+`-p` *(Optional)*: Plotting mode to plot the data of this sim run  
+`-o [OUT]` *(Optional)*: Outputs the data of this sim run to a CSV file. A name OUT can be provided, otherwise the name will be the current Unix timestamp
 
 #### Examples:  
 ```zsh
 python src/main.py configs/iss.json 
-python src/main.py configs/test_angles.json -v
+python src/main.py configs/freefall.json -pv
+python src/main.py configs/test_angles.json -vo
+python src/main.py configs/tli.json -po "tli"
 ```
 
 We recommend setting your `D_T` value (the timestep length) in `constants.py` to be between 100 - 300. If you're looking for a faster run, you'll want to set it to be on the higher side of that range.
@@ -52,9 +55,10 @@ python src/utils/plot.py {file path}
 #### Example:  
 ```zsh
 python src/utils/plot.py runs/cislunarsim-355942804.csv
+python src/utils/plot.py runs/tli.csv
 ```
 
-*Note: The above is an example CSV file that does not exist locally on your system.*
+*Note: The above are example CSV files that don't necessarily exist locally on your system.*
 
 ## IMPORTANT: Python Version MUST be >=3.8
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -95,13 +95,13 @@ class Config:
 
             json_params = data.get("parameters", {})
             if json_params == {}:
-                log.warning("parameters are not specified")
+                log.warning("Parameters are not specified")
             json_init_cond = data.get("initial_condition", {})
             if json_init_cond == {}:
-                log.warning("initial conditions are not specified")
+                log.warning("Initial conditions are not specified")
             json_models = data.get("models", [])
             if json_models == []:
-                log.warning("models are not specified")
+                log.warning("Models are not specified")
 
             actual_models = []
             for model_str in json_models:

--- a/src/main.py
+++ b/src/main.py
@@ -111,7 +111,7 @@ def run_sim():
     data = sim.run()
 
     # don't store any data if the sim was not specified to output to a file
-    if sim.out != "None":
+    if sim.out != None:
         df_to_csv(data, sim.out)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -79,9 +79,12 @@ class SimRunner:
             try:
                 updated_states = self._sim.step()
                 self.state_history.append(updated_states)
-            except (Exception, KeyboardInterrupt) as e:
+            except (Exception) as e:
                 log.critical("Stopping sim due to unhandled exception:")
                 log.error(e, exc_info=True)
+                break
+            except (KeyboardInterrupt):
+                log.info("Stopping sim")
                 break
 
         return self.state_history

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from utils.matplotlib_util import Plot
 import argparse
 
 
-_DESCRIPTION = """CISLUNAR Simulation Runner!"""
+_DESCRIPTION = """Cislunar Sim Runner!"""
 
 
 class SimRunner:
@@ -38,7 +38,7 @@ class SimRunner:
             parser.add_argument(
                 "config",
                 type=str,
-                help="Initialize simulation with given path to json config file.",
+                help="initialize simulation with given path to json config file",
             )
             parser.add_argument(
                 "-v",
@@ -103,6 +103,8 @@ class SimRunner:
 def run_sim():
     sim = SimRunner()
     data = sim.run()
+
+    # don't store any data if the sim was run in headless mode
     if not sim.headless:
         df_to_csv(data)
 

--- a/src/main.py
+++ b/src/main.py
@@ -47,20 +47,26 @@ class SimRunner:
                 help="set the logging level to DEBUG instead of INFO",
             )
             parser.add_argument(
-                "-l",
-                "--headless",
+                "-p",
+                "--plot",
                 action="store_true",
-                help="run the sim without saving to a csv or plotting the data"
+                help="plot the sim output"
             )
-
+            parser.add_argument(
+                "-o",
+                "--out",
+                const="None",
+                nargs="?",
+                help="write the sim output to a CSV file"
+            )
+            
             # Parser command line arguments
             args = parser.parse_args()
 
             # Set Logging level of "Sim" based on --verbose argument.
             log.setLevel(logging.DEBUG) if args.verbose else log.setLevel(logging.INFO)
-
-            self.headless = args.headless == True
-
+            self.out = args.out
+            self.plot = args.plot
             self._sim = CislunarSim(Config.make_config(args.config))
 
         self.state_history = []
@@ -78,7 +84,7 @@ class SimRunner:
 
         log.setLevel(logging.INFO)  # to prevent being spammed by matplotlib's debug logs (doesn't work)
 
-        if not self.headless:
+        if self.plot:
             data_plot = Plot(run_df)
             data_plot.plot_data()
         
@@ -104,9 +110,9 @@ def run_sim():
     sim = SimRunner()
     data = sim.run()
 
-    # don't store any data if the sim was run in headless mode
-    if not sim.headless:
-        df_to_csv(data)
+    # don't store any data if the sim was not specified to output to a file
+    if sim.out != "None":
+        df_to_csv(data, sim.out)
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -46,12 +46,20 @@ class SimRunner:
                 action="store_true",
                 help="set the logging level to DEBUG instead of INFO",
             )
+            parser.add_argument(
+                "-l",
+                "--headless",
+                action="store_true",
+                help="run the sim without saving to a csv or plotting the data"
+            )
 
             # Parser command line arguments
             args = parser.parse_args()
 
             # Set Logging level of "Sim" based on --verbose argument.
             log.setLevel(logging.DEBUG) if args.verbose else log.setLevel(logging.INFO)
+
+            self.headless = args.headless == True
 
             self._sim = CislunarSim(Config.make_config(args.config))
 
@@ -69,9 +77,11 @@ class SimRunner:
         run_df = states_to_df(states)
 
         log.setLevel(logging.INFO)  # to prevent being spammed by matplotlib's debug logs (doesn't work)
-        data_plot = Plot(run_df)
-        data_plot.plot_data()
 
+        if not self.headless:
+            data_plot = Plot(run_df)
+            data_plot.plot_data()
+        
         return run_df
 
     def _run(self):
@@ -91,8 +101,10 @@ class SimRunner:
 
 
 def run_sim():
-    data = SimRunner().run()
-    df_to_csv(data)
+    sim = SimRunner()
+    data = sim.run()
+    if not sim.headless:
+        df_to_csv(data)
 
 
 if __name__ == "__main__":

--- a/src/utils/data_handling.py
+++ b/src/utils/data_handling.py
@@ -27,7 +27,7 @@ def states_to_df(states: List[PropagatedOutput]) -> pd.DataFrame:
     return complete_df
 
 
-def df_to_csv(dataframe: pd.DataFrame, path: Optional[Union[str, Path]] = None):
+def df_to_csv(dataframe: pd.DataFrame, name: str, path: Optional[Union[str, Path]] = None):
     """Creates and writes the data in [dataframe] into a csv file at [path]
 
     Args:
@@ -36,7 +36,9 @@ def df_to_csv(dataframe: pd.DataFrame, path: Optional[Union[str, Path]] = None):
     """
     if path is None:
         path = SIM_ROOT / "runs"
-    dataframe.to_csv(f"{path}/cislunarsim-{current_int_time()}.csv")
+    if name == "None":
+        name = current_int_time()
+    dataframe.to_csv(f"{path}/cislunarsim-{name}.csv")
 
 
 def save_anim(anim: FuncAnimation):

--- a/src/utils/data_handling.py
+++ b/src/utils/data_handling.py
@@ -37,8 +37,8 @@ def df_to_csv(dataframe: pd.DataFrame, name: str, path: Optional[Union[str, Path
     if path is None:
         path = SIM_ROOT / "runs"
     if name == "None":
-        name = current_int_time()
-    dataframe.to_csv(f"{path}/cislunarsim-{name}.csv")
+        name = f"cislunarsim-{current_int_time()}"
+    dataframe.to_csv(f"{path}/{name}.csv")
 
 
 def save_anim(anim: FuncAnimation):


### PR DESCRIPTION
### Summary

Some command line quality of life improvements. Added a headless mode that will stop the sim from storing any data to a CSV and not run data viz. Also separated out the stopping conditions for a normal KeyboardInterrupt from a general exception to stop error messages from being printed out every time you stop it (Probably confusing for new users of the sim, jumbles with verbose mode output).


_Chunky runs folder_
![image](https://user-images.githubusercontent.com/47681797/201491869-52cee72e-b958-4e1c-85c6-27d77682e6d6.png)



### Testing
Ran in all possible combinations of modes


### Notes
How do you guys feel about this version of a headless mode? Would we want something that doesn't store CSV data but still runs data viz instead of/in addition to this? Should this be the default mode of the sim? (I feel like those CSVs never really get used)


### Comments
- [x] Add an x between the brackets if you commented your code well!
