### PR TITLE
[WIP] Draft implementation: Integration of FSW into sim - sim side

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+CISLUNAR_BASE_DIR=cislunar_data
+SURRENDER_LOCAL_DIR=outside_repo
+FOR_FLIGHT=0
+LOG=1
+TEST=1

--- a/src/core/sim.py
+++ b/src/core/sim.py
@@ -7,6 +7,7 @@ from core.models.model_list import ModelContainer
 from utils.log import log
 from utils.constants import R_EARTH, EARTH_SOI
 from core.event import Event, NormalEvent
+from fsw_main.main import MainSatelliteThread
 
 class CislunarSim:
     """This class consolidates all parts of the sim (config, models, state). It is responsible for 
@@ -22,6 +23,7 @@ class CislunarSim:
         self.should_run = True
         self.num_iters = 0
         self.event_queue : "Queue[Event]" = Queue()
+        self.main_thread = MainSatelliteThread(is_sim_run=True)
 
     def step(self) -> PropagatedOutput:
         """step() is the combined true and observed state after one step."""
@@ -32,7 +34,8 @@ class CislunarSim:
         current_event = self.event_queue.get()
         self.state_time, self.observed_state = current_event.evaluate(self.state_time)
         # TODO: Feed outputs of sensor models into FSW and return actuator's state as part of `PropagatedOutput`
-
+        fsw_output = self.main_thread.step(self.observed_state.__dict__)
+        print(fsw_output)
         # check if we should stop the sim
         self.should_run = not (self.should_stop())
         self.num_iters += 1


### PR DESCRIPTION
### Summary
This PR is the first step from the sim side towards integrating the flight software into the sim. It is a draft and most likely needs some more revisions before it can be merged in, after we spend some time testing it with FSW.

The latter half of Section 5 of my final report gives some more context to this change: https://cornell.box.com/s/d4qeksk9u0yf6tncf7p9uzw2w8dsuflm

Changes made:
- Add .env file because the flight software depends on some environment variables to run
- import MainSatelliteThread from FSW into `sim.py` and create a new instance of it to use its step method within the sim's step method

This PR should NOT be merged in until this FSW PR is: https://github.com/Cislunar-Explorers/FlightSoftware/pull/174
We also need to get FSW into a state in which there are no more "hardware errors" caused by a few last hardware calls/imports that haven't been addressed. But extensive testing of the FSW with the sim can only be done after the above linked PR is merged into master.
### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
Successfully pip installed `.tar.gz` file into sim. The "hardware errors" that appear are consistent between running flight software by itself and running it alongside the sim. So, I conclude that there aren't any major integration issues at this point.

Here are some instructions on how to test this:

Reference this tutorial as well: https://packaging.python.org/en/latest/tutorials/packaging-projects/

In **FSW**:
- Run `python3 -m pip install --upgrade build` to install the package needed to package the python project.
- Run `python3 -m build` to compile the `.tar.gz` file you will install into the sim.
- Two files will be created and placed into a `dist/` directory. You will need the one with extension `.tar.gz`.

In **sim**:
- Put the `.tar.gz` file in some directory within the sim.
- Run `pip install <directory_of_fsw.tar.gz` (yes, no -e flag). For example, if you placed the file within the parent directory, you can just run `pip install CislunarExplorers-0.1.tar.gz`.
- Run the sim like normal, with a config JSON file.

### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->
- You will need to use setup tools to compile FSW (either from this branch https://github.com/Cislunar-Explorers/FlightSoftware/pull/174 or from master if the changes are already merged in) into a `.tar.gz` file to test this. 

- There will be more changes needed in FSW that will be uncovered after running the sim with FSW.
- Cannot be merged into main until some more FSW changes to be made, mostly regarding some last hardware library imports/calls that still need to be sim'ed out.
- Long-term note: A solution that has the dynamic attributes of git, without the module and namespacing issues, is the ultimate goal here. For now, this method of building FSW each time we push an update using setuptools and then pip installing it each time into the sim, will be a preliminary step to at least connect the flight software and the sim, as it will involve less major refactoring than the first method.

### Comments
- [x] Add an x between the brackets if you commented your code well!
