### PR TITLE
Share observed state through python Shared Memory

### DIFF
--- a/src/core/sim.py
+++ b/src/core/sim.py
@@ -7,6 +7,7 @@ from core.models.model_list import ModelContainer
 from utils.log import log
 from utils.constants import R_EARTH, EARTH_SOI
 from core.event import Event, NormalEvent
+from multiprocessing import shared_memory
 
 class CislunarSim:
     """This class consolidates all parts of the sim (config, models, state). It is responsible for 
@@ -32,7 +33,11 @@ class CislunarSim:
         current_event = self.event_queue.get()
         self.state_time, self.observed_state = current_event.evaluate(self.state_time)
         # TODO: Feed outputs of sensor models into FSW and return actuator's state as part of `PropagatedOutput`
-
+        # Current implementation uses Shared Memory to pass data
+        shm = shared_memory.SharedMemory(name="Simulator Data") 
+        observedArray = self.observed_state.to_array()
+        stateArray = np.ndarray(observedArray.shape, dtype=observedArray.dtype, buffer=shm.buf)
+        stateArray[:] = observedArray[:]
         # check if we should stop the sim
         self.should_run = not (self.should_stop())
         self.num_iters += 1

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from core.state import state
 import pandas as pd
 from utils.matplotlib_util import Plot
 from multiprocessing import shared_memory
-import numpy as np
+from utils.constants import SHRD_MEM_NAME
 
 
 import argparse
@@ -83,7 +83,7 @@ class SimRunner:
         Returns:
             pd.DataFrame: Dataframe of the true and observed states at each instant of observation.
         """
-        shm = shared_memory.SharedMemory(create=True, name="Simulator Data", size=getsizeof(state.ObservedState().to_array())) # Create shared memory
+        shm = shared_memory.SharedMemory(create=True, name=SHRD_MEM_NAME, size=getsizeof(state.ObservedState().to_array())) # Create shared memory
         
         states = self._run()
         run_df = states_to_df(states)

--- a/src/main.py
+++ b/src/main.py
@@ -102,11 +102,6 @@ class SimRunner:
         while self._sim.should_run:
             try:
                 updated_states = self._sim.step()
-                # shm = shared_memory.SharedMemory(name="Simulator Data")
-                # dummyArray = state.ObservedState().to_array()
-                # dataArray = np.ndarray(dummyArray.shape, dtype=dummyArray.dtype, buffer=shm.buf)
-                # assert (updated_states.observed_state.to_array() == dataArray).all()
-                # The above code asserts the data stored in the shared memory is the same as is propagated elsewhere
                 self.state_history.append(updated_states)
             except (Exception) as e:
                 log.critical("Stopping sim due to unhandled exception:")

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 SIM_ROOT = (Path(__file__).parent / "../..").resolve()
 SRC_ROOT = (Path(__file__).parent / "..").resolve()
+SHRD_MEM_NAME = "Simulator Data"
 
 
 class StringEnum(str, Enum):


### PR DESCRIPTION
### Summary
<!-- What changes were made? What features were added? What bugs were fixed? -->
This PR addresses Jira ticket [CISLUNAR-450](https://jira.cornell.edu/browse/CISLUNAR-450)   <!-- Replace ### with JIRA ticket number -->

Using shared memory under the name "Simulator Data", the observed data of the simulator will now be shared with any other python processes running on the machine. This pull request also has certain safety to prevent another process carelessly closing the memory from crashing the simulator



### Testing
<!-- How was your code tested? Include locations of test code and/or documents -->
Brief running of the simulator, and accessing of memory from another python process running on the same machine

### Notes
<!--- List any major or minor points, future thoughts, and/or future concerns -->
In essence, this should make the simulator capable of being used by any python flight software with no further modifications. However, when the observed state is solidified in its shape (number of elements), this should be documented such that other programs can consistently access the data given set shape.

Also, this only supports Sim -> FSW communication, much more work will need to be done for the FSW -> Sim communication
### Comments
- [x] Add an x between the brackets if you commented your code well!
